### PR TITLE
Added feature #131, vertical and horizontal discrete legends.

### DIFF
--- a/R/ColorMapping-class.R
+++ b/R/ColorMapping-class.R
@@ -28,7 +28,7 @@ ColorMapping = setClass("ColorMapping",
 		col_fun = "function", # function to map values to colors
 		type    = "character",  # continuous or discrete
 		name    = "character",  # used to map to the dataset and taken as the title of the legend
-		na_col  = "character"	
+		na_col  = "character"
 	)
 )
 
@@ -38,7 +38,7 @@ ColorMapping = setClass("ColorMapping",
 # == param
 # -name name for this color mapping. The name is automatically generated if it is not specified.
 # -colors discrete colors.
-# -levels levels that correspond to ``colors``. If ``colors`` is name indexed, 
+# -levels levels that correspond to ``colors``. If ``colors`` is name indexed,
 #         ``levels`` can be ignored.
 # -col_fun color mapping function that maps continuous values to colors.
 # -breaks breaks for the continuous color mapping. If ``col_fun`` is
@@ -46,7 +46,7 @@ ColorMapping = setClass("ColorMapping",
 # -na_col colors for ``NA`` values.
 #
 # == detail
-# ``colors`` and ``levels`` are used for discrete color mapping, ``col_fun`` and 
+# ``colors`` and ``levels`` are used for discrete color mapping, ``col_fun`` and
 # ``breaks`` are used for continuous color mapping.
 #
 # == value
@@ -55,7 +55,7 @@ ColorMapping = setClass("ColorMapping",
 # == author
 # Zuguang Gu <z.gu@dkfz.de>
 #
-ColorMapping = function(name, colors = NULL, levels = NULL, 
+ColorMapping = function(name, colors = NULL, levels = NULL,
 	col_fun = NULL, breaks = NULL, na_col = "#FFFFFF") {
 
 	.Object = new("ColorMapping")
@@ -92,7 +92,7 @@ ColorMapping = function(name, colors = NULL, levels = NULL,
 				stop("You should provide breaks.\n")
 			}
 		}
-		
+
 		le1 = grid.pretty(range(breaks))
 		le2 = pretty(breaks, n = 3)
 		if(abs(length(le1) - 5) < abs(length(le2) - 5)) {
@@ -100,7 +100,7 @@ ColorMapping = function(name, colors = NULL, levels = NULL,
 		} else {
 			le = le2
 		}
-		
+
 		.Object@colors = col_fun(le)
 		.Object@levels = le
 		.Object@col_fun = col_fun
@@ -174,7 +174,7 @@ setMethod(f = "show",
 setMethod(f = "map_to_colors",
 	signature = "ColorMapping",
 	definition = function(object, x) {
-	
+
 	if(is.factor(x)) x = as.vector(x)
 	original_attr = attributes(x)
 	x2 = vector(length = length(x))
@@ -188,7 +188,7 @@ setMethod(f = "map_to_colors",
 			msg = paste0(object@name, ": cannot map colors to some of the levels:\n", paste(setdiff(x[!lna], object@levels), sep = ", ", collapse = ", "))
 			stop(msg)
 		}
-		
+
 		x2[lna] = object@na_col
 		x2[!lna] = object@colors[ x[!lna] ]
 	} else {
@@ -241,7 +241,7 @@ setMethod(f = "map_to_colors",
 setMethod(f = "color_mapping_legend",
 	signature = "ColorMapping",
 	definition = function(object, ...,
-	plot = TRUE, 
+	plot = TRUE,
 	title = object@name,
 	title_gp = gpar(fontsize = 10, fontface = "bold"),
 	title_position = c("topleft", "topcenter", "leftcenter", "lefttop"),
@@ -291,7 +291,7 @@ setMethod(f = "color_mapping_legend",
 			labels = rev(labels)
 		}
 		gf = Legend(at = at, labels = labels, title = title, title_gp = title_gp, grid_height = grid_height,
-			grid_width = grid_width, border = border, labels_gp = labels_gp, nrow = nrow, ncol = ncol,
+			grid_width = grid_width, border = border, labels_gp = labels_gp, direction = legend_direction, nrow = nrow, ncol = ncol,
 			legend_gp = gpar(fill = map_to_colors(object, at)), title_position = title_position)
 
 	} else {
@@ -301,7 +301,7 @@ setMethod(f = "color_mapping_legend",
 			legend_width = legend_width, legend_height = legend_height, title_position = title_position)
 
 	}
-	
+
 	if(plot) {
 		pushViewport(viewport(..., width = grobWidth(gf), height = grobHeight(gf), name = paste0("legend_", object@name)))
 		grid.draw(gf)

--- a/R/ColorMapping-class.R
+++ b/R/ColorMapping-class.R
@@ -223,7 +223,7 @@ setMethod(f = "map_to_colors",
 # -ncol if there are too many legend grids, they can be put as an array, this controls number of columns
 # -legend_height height of the legend, only works when ``color_bar`` is ``continuous`` and ``direction`` is ``vertical``
 # -legend_width width of the legend, only works when ``color_bar`` is ``continuous`` and ``direction`` is ``horizontal``
-# -legend_direction when ``color_bar`` is ``continuous``, should the legend be vertical or horizontal?
+# -legend_direction when ``color_bar`` is ``continuous``, should the legend be vertical or horizontal? When ``color_bar`` is ``discrete``, should the items in the legend proceed vertically or horizontally?
 # -param will be parsed if the parameters are specified as a list
 # -... pass to `grid::viewport`.
 #

--- a/R/Legend.R
+++ b/R/Legend.R
@@ -21,7 +21,7 @@
 # -size size of points
 # -legend_height height of the whole legend, used when ``col_fun`` is specified and ``direction`` is set to ``vertical``
 # -legend_width width of the whole legend, used when ``col_fun`` is specified  and ``direction`` is set to ``horizontal``
-# -direction direction of the continuous legend
+# -direction direction of the continuous or discrete legend
 # -title title of the legend
 # -title_gp graphic parameters of title
 # -title_position position of title according to the legend

--- a/man/color_mapping_legend-ColorMapping-method.rd
+++ b/man/color_mapping_legend-ColorMapping-method.rd
@@ -44,7 +44,7 @@ Draw legend based on color mapping
   \item{ncol}{if there are too many legend grids, they can be put as an array, this controls number of columns}
   \item{legend_height}{height of the legend, only works when \code{color_bar} is \code{continuous} and \code{direction} is \code{vertical}}
   \item{legend_width}{width of the legend, only works when \code{color_bar} is \code{continuous} and \code{direction} is \code{horizontal}}
-  \item{legend_direction}{when \code{color_bar} is \code{continuous}, should the legend be vertical or horizontal?}
+  \item{legend_direction}{when \code{color_bar} is \code{continuous}, should the legend be vertical or horizontal? When \code{color_bar} is \code{discrete}, should the items in the legend proceed vertically or horizontally?}
   \item{param}{will be parsed if the parameters are specified as a list}
   \item{...}{pass to \code{\link[grid]{viewport}}.}
 

--- a/vignettes/s5.legend.Rmd
+++ b/vignettes/s5.legend.Rmd
@@ -35,7 +35,7 @@ according to the input matrix and annotations, while also provide flexibility to
 
 ## Basic settings
 
-Legends for all heatmaps and row annotations are drawn together and legends for all column annotations are drawn together. 
+Legends for all heatmaps and row annotations are drawn together and legends for all column annotations are drawn together.
 The legends for heatmaps and legends for annotations are put in independent viewports.
 
 ```{r legend_default, fig.width = 8, fig.keep = "all"}
@@ -48,9 +48,9 @@ mat = rbind(mat, matrix(rnorm(40, -2), 4, 10))
 rownames(mat) = paste0("R", 1:12)
 colnames(mat) = paste0("C", 1:10)
 
-ha_column = HeatmapAnnotation(df = data.frame(type1 = c(rep("a", 5), rep("b", 5))), 
+ha_column = HeatmapAnnotation(df = data.frame(type1 = c(rep("a", 5), rep("b", 5))),
     col = list(type1 = c("a" =  "red", "b" = "blue")))
-ha_row = rowAnnotation(df = data.frame(type2 = c(rep("A", 6), rep("B", 6))), 
+ha_row = rowAnnotation(df = data.frame(type2 = c(rep("A", 6), rep("B", 6))),
     col = list(type2 = c("A" =  "green", "B" = "orange")), width = unit(1, "cm"))
 
 ht1 = Heatmap(mat, name = "ht1", column_title = "Heatmap 1", top_annotation = ha_column)
@@ -73,15 +73,15 @@ draw(ht_list, heatmap_legend_side = "left", annotation_legend_side = "bottom")
 draw(ht_list, show_heatmap_legend = FALSE, show_annotation_legend = FALSE)
 ```
 
-You can choose to only show some of the heatmap legends by setting `show_heatmap_legend` to 
+You can choose to only show some of the heatmap legends by setting `show_heatmap_legend` to
 a logical value when constructing single heatmaps.
 Also `HeatmapAnnotation()` (or the shortcut function `columnAnnotation()` and `rowAnnotation()`) provides
 `show_legend` argument to control visibility of annotation legends.
 
 ```{r legend_show_part, fig.width = 10}
-ha_column = HeatmapAnnotation(df = data.frame(type1 = c(rep("a", 5), rep("b", 5))), 
+ha_column = HeatmapAnnotation(df = data.frame(type1 = c(rep("a", 5), rep("b", 5))),
     col = list(type1 = c("a" =  "red", "b" = "blue")), show_legend = FALSE)
-ha_row = rowAnnotation(df = data.frame(type2 = c(rep("A", 6), rep("B", 6))), 
+ha_row = rowAnnotation(df = data.frame(type2 = c(rep("A", 6), rep("B", 6))),
     col = list(type2 = c("A" =  "green", "B" = "orange")), show_legend = FALSE, width = unit(1, "cm"))
 
 ht1 = Heatmap(mat, name = "ht1", column_title = "Heatmap 1", top_annotation = ha_column)
@@ -91,7 +91,7 @@ ht1 + ht2 + ha_row
 
 ## Customization of legends
 
-Legend itself can be flexibly customized. Parameters for making the legend can be set by `heatmap_legend_param` 
+Legend itself can be flexibly customized. Parameters for making the legend can be set by `heatmap_legend_param`
 (for heatmap) or `annotation_legend_param` (for annotations).
 The parameters that can be set are as follows:
 
@@ -106,7 +106,7 @@ The parameters that can be set are as follows:
 - `labels`: labels which correspond to the breaks values
 - `labels_gp`: graphic parameters for legend labels
 - `nrow` and `ncol`: if there are too many legends, they can be put into an array. These two parameters controls number of rows or columns
-- `legend_direction`: when `color_bar` is set to `continuous`, it controls the direction of the legend, possible values are `vertical` and `horizontal`
+- `legend_direction`: Controls the direction of the legend, possible values are `vertical` and `horizontal`. Works for both `continuous` and `discrete`
 - `legend_width` and `legend_height`: when `color_bar` is `continuous`, the width or height of the legend
 
 
@@ -115,21 +115,21 @@ Following example changes the default graphic parameters for labels and titles:
 ```{r heatmap_list_advanced, fig.width = 10}
 df = data.frame(type = c(rep("a", 5), rep("b", 5)))
 ha = HeatmapAnnotation(df = df, col = list(type = c("a" =  "red", "b" = "blue")),
-    annotation_legend_param = list(type = list(title = "TYPE", title_gp = gpar(fontsize = 14), 
+    annotation_legend_param = list(type = list(title = "TYPE", title_gp = gpar(fontsize = 14),
                                                labels_gp = gpar(fontsize = 8))))
 ht1 = Heatmap(mat, name = "ht1", column_title = "Heatmap 1", top_annotation = ha)
-ht2 = Heatmap(mat, name = "ht2", column_title = "Heatmap 2", 
-    heatmap_legend_param = list(title = "Heatmap2", title_gp = gpar(fontsize = 8), 
+ht2 = Heatmap(mat, name = "ht2", column_title = "Heatmap 2",
+    heatmap_legend_param = list(title = "Heatmap2", title_gp = gpar(fontsize = 8),
         labels_gp = gpar(fontsize = 14)))
 ht1 + ht2
 ```
 
-You can specify break values and break labels (both for character values and numeric values) by `at` and `labels` 
+You can specify break values and break labels (both for character values and numeric values) by `at` and `labels`
 in corresponding `heatmap_legend_param` and `annotation_legend_param`. Note `at` can also be character break values.
 
 ```{r self_define_heatmap_legend, fig.width = 10}
 ha = HeatmapAnnotation(df = df, col = list(type = c("a" =  "red", "b" = "blue")),
-    annotation_legend_param = list(type = list(title = "TYPE", title_gp = gpar(fontsize = 14), 
+    annotation_legend_param = list(type = list(title = "TYPE", title_gp = gpar(fontsize = 14),
         labels_gp = gpar(fontsize = 8), at = c("a", "b"), labels = c("A", "B"))))
 ht1 = Heatmap(mat, name = "ht1", column_title = "Heatmap 1", top_annotation = ha,
     heatmap_legend_param = list(at = c(-3, 0, 3), labels = c("-three", "zero", "+three")))
@@ -156,13 +156,21 @@ ha_chr = rowAnnotation(chr = sample(paste0("chr", 1:20), nrow(mat), replace = TR
 ht1 = Heatmap(mat, name = "ht1", show_heatmap_legend = FALSE)
 draw(ht1 + ha_chr, heatmap_legend_side = "bottom")
 ```
+If you want to order a discrete legend by column instead of row, use the direction argument:
+
+```{r, fig.width = 6}
+ha_chr = rowAnnotation(chr = sample(paste0("chr", 1:20), nrow(mat), replace = TRUE),
+    annotation_legend_param = list(chr = list(nrow = 2, title = "chr", title_position = "leftcenter", legend_direction = "vertical")),
+    width = unit(5, "mm"))
+ht1 = Heatmap(mat, name = "ht1", show_heatmap_legend = FALSE)
+draw(ht1 + ha_chr, heatmap_legend_side = "bottom")
 
 Discrete color bar for can be used for continuous values, if you specify `color_bar` to `discrete`.
 For the simple annotation which contains continuous values, `color_bar` can also be set to `discrete`.
 
 ```{r}
-ha = HeatmapAnnotation(df = data.frame(value = runif(10)), 
-    col = list(value = colorRamp2(c(0, 1), c("white", "blue"))), 
+ha = HeatmapAnnotation(df = data.frame(value = runif(10)),
+    col = list(value = colorRamp2(c(0, 1), c("white", "blue"))),
     annotation_legend_param = list(color_bar = "discrete", at = c(0, 0.5, 1)))
 Heatmap(mat, name = "ht1", top_annotation = ha, heatmap_legend_param = list(color_bar = "discrete"))
 ```
@@ -185,7 +193,7 @@ If you want to change default settings for all heatmaps/annotations, you can set
 
 ```{r, fig.width = 10}
 ht_global_opt(heatmap_legend_title_gp = gpar(fontsize = 16), annotation_legend_labels_gp = gpar(fontface = "italic"))
-ha = HeatmapAnnotation(df = data.frame(value = runif(10)), 
+ha = HeatmapAnnotation(df = data.frame(value = runif(10)),
     col = list(value = colorRamp2(c(0, 1), c("white", "blue"))))
 ht1 = Heatmap(mat, name = "ht1", column_title = "Heatmap 1", top_annotation = ha)
 ht2 = Heatmap(mat, name = "ht2", column_title = "Heatmap 2", heatmap_legend_param = list(title_gp = gpar(fontsize = 8)))


### PR DESCRIPTION
Made minor edits to allow for discrete legends to be ordered by row, or by column. (#131)

This creats the original functionality, and is the default value: `legend_direction = "horizontal"`

<img width="247" alt="screen shot 2017-10-31 at 11 40 28 pm" src="https://user-images.githubusercontent.com/18296227/32266717-aa5968d2-bea5-11e7-86ff-bcdf6e69292d.png">

And here is selecting a vertical discrete legend: `legend_direction = "vertical"`

<img width="253" alt="screen shot 2017-11-01 at 1 36 28 am" src="https://user-images.githubusercontent.com/18296227/32266726-b4130a22-bea5-11e7-8d64-0587e4f335b4.png">


