### PR TITLE
Feature/s4vector version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Maintainer: Zuguang Gu <z.gu@dkfz.de>
 Depends: R (>= 3.1.2), methods, grid, graphics, stats, grDevices
 Imports: circlize (>= 0.4.5), GetoptLong, colorspace, clue,
     RColorBrewer, GlobalOptions (>= 0.1.0), parallel, png,
-    digest, S4Vectors, IRanges
+    digest, S4Vectors (>=0.27.12), IRanges
 Suggests: testthat (>= 1.0.0), knitr, markdown, dendsort, 
     Cairo, jpeg, tiff, fastcluster,
     dendextend (>= 1.0.1), grImport, grImport2, glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Maintainer: Zuguang Gu <z.gu@dkfz.de>
 Depends: R (>= 3.1.2), methods, grid, graphics, stats, grDevices
 Imports: circlize (>= 0.4.5), GetoptLong, colorspace, clue,
     RColorBrewer, GlobalOptions (>= 0.1.0), parallel, png,
-    digest, S4Vectors (>=0.26.1), IRanges
+    digest, S4Vectors, IRanges
 Suggests: testthat (>= 1.0.0), knitr, markdown, dendsort, 
     Cairo, jpeg, tiff, fastcluster,
     dendextend (>= 1.0.1), grImport, grImport2, glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,10 +5,11 @@ Version: 2.5.5
 Date: 2020-06-26
 Author: Zuguang Gu
 Maintainer: Zuguang Gu <z.gu@dkfz.de>
+biocViews:
 Depends: R (>= 3.1.2), methods, grid, graphics, stats, grDevices
 Imports: circlize (>= 0.4.5), GetoptLong, colorspace, clue,
     RColorBrewer, GlobalOptions (>= 0.1.0), parallel, png,
-    digest, S4Vectors (>=0.27.12), IRanges
+    digest, S4Vectors (>= 0.26.1), IRanges
 Suggests: testthat (>= 1.0.0), knitr, markdown, dendsort, 
     Cairo, jpeg, tiff, fastcluster,
     dendextend (>= 1.0.1), grImport, grImport2, glue,


### PR DESCRIPTION
* Related to this issue: https://github.com/jokergoo/ComplexHeatmap/issues/563
* Fixed an error here:  https://github.com/jokergoo/ComplexHeatmap/pull/565
    * There needed to be a space `(>= 0.26.1)` or otherwise there's an error:
```
Invalid comparison operator in dependency: S4Vectors (>=0.26.1)
```
or 
```
* checking DESCRIPTION meta-information ... ERROR
Malformed Depends or Suggests or Imports or Enhances field.
Offending entries:
  S4Vectors(>=0.27.12)
Entries must be names of packages optionally followed by '<=' or '>=',
white space, and a valid version number in parentheses.
```