### PR TITLE
fix invalid characters in tempfile pattern

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Maintainer: Zuguang Gu <z.gu@dkfz.de>
 Depends: R (>= 3.1.2), methods, grid, graphics, stats, grDevices
 Imports: circlize (>= 0.4.5), GetoptLong, colorspace, clue,
     RColorBrewer, GlobalOptions (>= 0.1.0), parallel, png,
-    digest, S4Vectors (>= 0.26.1), IRanges
+    digest, S4Vectors (>= 0.26.1), IRanges, fs
 Suggests: testthat (>= 1.0.0), knitr, markdown, dendsort, 
     Cairo, jpeg, tiff, fastcluster,
     dendextend (>= 1.0.1), grImport, grImport2, glue,

--- a/R/Heatmap-draw_component.R
+++ b/R/Heatmap-draw_component.R
@@ -113,7 +113,7 @@ setMethod(f = "draw_heatmap_body",
         }
 
         temp_dir = tempdir()
-        temp_image = tempfile(pattern = paste0(".heatmap_body_", object@name, "_", kr, "_", kc), tmpdir = temp_dir, fileext = paste0(".", device_info[2]))
+        temp_image = tempfile(pattern = fs::path_sanitize(paste0(".heatmap_body_", object@name, "_", kr, "_", kc)), tmpdir = temp_dir, fileext = paste0(".", device_info[2]))
         device_fun = getFromNamespace(raster_device, ns = device_info[1])
 
         if(raster_by_magick) {


### PR DESCRIPTION
Invalid characters in `heatmap` parameter `name` will cause error while tempfile creating (edit: at least on windows).

To fix this, the pr import package `fs` and use `fs::path_sanitize` for tempfile pattern.