### PR TITLE
Fix `labels_col` conversion for ComplexHeatmap::pheatmap

### DIFF
--- a/R/pheatmap_translate.R
+++ b/R/pheatmap_translate.R
@@ -333,7 +333,7 @@ pheatmap = function(mat,
     }
 
     if(!is.null(labels_col)) {
-        ht_param$labels_col = labels_col
+        ht_param$column_labels = labels_col
     }
 
     if(!is.null(gaps_row)) {


### PR DESCRIPTION
Looks like the input was mistakenly left as `labels_col`.  This updates it to be named `column_labels`.