### PR TITLE
Ensures `.libPaths()` in individual workers

### DIFF
--- a/R/densityHeatmap.R
+++ b/R/densityHeatmap.R
@@ -294,9 +294,10 @@ ks_dist = function(data, cores = 1) {
 	ind_mat = expand.grid(seq_len(nc), seq_len(nc))
 	ind_mat = ind_mat[  ind_mat[, 1] > ind_mat[, 2], , drop = FALSE]
 	
+	lp <- .libPaths()
 	registerDoParallel(cores)
 	v <- foreach (ind = seq_len(nrow(ind_mat))) %dopar% {
-
+  	.libPaths(lp) # Ensure lib paths in individual cluster
 		i = ind_mat[ind, 1]
 		j = ind_mat[ind, 2]
 		suppressWarnings(d <- ks_dist_pair(data[[i]], data[[j]]))


### PR DESCRIPTION
There is an issue with `densityHeatmap()` if some dependencies of `ComplexHeatmap` locate at difference library paths.
This can be resolved by reinitiating `.libPaths()` at the beginning of `foreach` in `doParallel`.

The solution is adapted from a similar issue in package `future`: https://stackoverflow.com/questions/52276088/how-to-set-libpaths-checkpoint-on-workers-when-running-parallel-computation-i

This change fixes our problem, so I think it can be helpful for other users of your package, too.