### PR TITLE
Fix for transposed UpSet plot left annotation

### DIFF
--- a/R/Upset.R
+++ b/R/Upset.R
@@ -1458,7 +1458,7 @@ UpSet = function(m,
 		}
 		la = left_annotation
 		if(length(la) == 1) {
-			ta_call = substitute(right_annotation)
+			ta_call = substitute(left_annotation)
 			ta_call = as.list(ta_call)
 			if(as.character(ta_call[[1]]) == "upset_left_annotation") {
 				if(!"gp" %in% names(as.list(ta_call))) {


### PR DESCRIPTION
I have noticed an issue with a specific use case of the UpSet plot.

I have tried to create an "transposed" UpSet plot with the sets in columns and the combinations in rows (i.e. `t(m)`). With this, I could not add a `left_annotation`. The error for that was

```r
Error in ta_call[[1]] : subscript out of bounds
```
Fortunately, I quickly found the reason for that error and fixed it. It was in fact just a single variable name that was wrong, probably from copying it over from the right_annotation.

Here also a minimal working example for the case that caused the error:
```r
lt = list(a = sample(letters, 5),
          b = sample(letters, 10),
          c = sample(letters, 15))
m1 = make_comb_mat(lt)

UpSet(t(m1), left_annotation = upset_left_annotation(t(m1)))
```