### PR TITLE
add `heatmap_legend_list` and `annotation_legend_list` slots

### DIFF
--- a/R/Heatmap-class.R
+++ b/R/Heatmap-class.R
@@ -63,7 +63,8 @@ Heatmap = setClass("Heatmap",
         right_annotation_param = "list",
 
         heatmap_param = "list",
-
+        heatmap_legend_list = "list",
+        annotation_legend_list = "list",
         layout = "list"
     ),
     contains = "AdditiveUnit"
@@ -288,7 +289,8 @@ Heatmap = function(matrix, col, name,
     width = NULL,
     heatmap_height = unit(1, "npc"), 
     height = NULL,
-
+    heatmap_legend_list = list(),
+    annotation_legend_list = list(),
     show_heatmap_legend = TRUE,
     heatmap_legend_param = list(title = name),
 
@@ -1023,6 +1025,8 @@ Heatmap = function(matrix, col, name,
     .Object@heatmap_param$height = heatmap_height
     .Object@heatmap_param$show_heatmap_legend = show_heatmap_legend
     .Object@heatmap_param$use_raster = use_raster
+    .Object@heatmap_legend_list <- heatmap_legend_list
+    .Object@annotation_legend_list <- annotation_legend_list
 
     if(missing(raster_device)) {
         if(requireNamespace("Cairo", quietly = TRUE)) {
@@ -1050,7 +1054,6 @@ Heatmap = function(matrix, col, name,
     if(ncol(matrix) == 0) {
         .Object@matrix_param$width = unit(0, "mm")
     }
-
     return(.Object)
 
 }

--- a/R/HeatmapList-layout.R
+++ b/R/HeatmapList-layout.R
@@ -811,7 +811,7 @@ setMethod(f = "make_layout",
             }
         }
     }
-    
+
     ############################################
     ## title on top or bottom
     if(!is.null(ht_opt$TITLE_PADDING)) {
@@ -960,6 +960,18 @@ setMethod(f = "make_layout",
             annotation_legend_list = list(annotation_legend_list)
         }
     }
+    heatmap_legend_list = c(
+        unlist(lapply(object@ht_list, function(x) {
+            x@heatmap_legend_list
+        }), recursive = FALSE, use.names = FALSE),
+        heatmap_legend_list
+    )
+    annotation_legend_list = c(
+        unlist(lapply(object@ht_list, function(x) {
+            x@annotation_legend_list
+        }), recursive = FALSE, use.names = FALSE),
+        annotation_legend_list
+    )
     if(merge_legends) {
         heatmap_legend_list = c(heatmap_legend_list, annotation_legend_list)
     }

--- a/man/Heatmap.Rd
+++ b/man/Heatmap.Rd
@@ -86,6 +86,8 @@ Heatmap(matrix, col, name,
     heatmap_height = unit(1, "npc"),
     height = NULL,
     
+    heatmap_legend_list = list(),
+    annotation_legend_list = list(),
     show_heatmap_legend = TRUE,
     heatmap_legend_param = list(title = name),
     
@@ -174,6 +176,8 @@ Heatmap(matrix, col, name,
   \item{height}{Height of the heatmap body.}
   \item{heatmap_width}{Width of the whole heatmap (including heatmap components)}
   \item{heatmap_height}{Height of the whole heatmap (including heatmap components). Check \url{https://jokergoo.github.io/ComplexHeatmap-reference/book/a-single-heatmap.html#size-of-the-heatmap} .}
+  \item{heatmap_legend_list}{use-defined legends which are put after the heatmap legends}
+  \item{annotation_legend_list}{user-defined legends which are put after the annotation legends}
   \item{show_heatmap_legend}{Whether show heatmap legend?}
   \item{heatmap_legend_param}{A list contains parameters for the heatmap legends. See \code{\link{color_mapping_legend,ColorMapping-method}} for all available parameters.}
   \item{use_raster}{Whether render the heatmap body as a raster image. It helps to reduce file size when the matrix is huge. If number of rows or columns is more than 2000, it is by default turned on. Note if \code{cell_fun} is set, \code{use_raster} is enforced to be \code{FALSE}.}


### PR DESCRIPTION
try to deal with https://github.com/jokergoo/ComplexHeatmap/issues/1138

```
library(ggplot2)
library(ComplexHeatmap)
x <- sample(1:10, 10L)
m <- rbind(1:10, 11:20)
rownames(m) <- paste0("row ", seq_len(nrow(m)))
colnames(m) <- paste0("col ", seq_len(ncol(m)))
draw(eheat::ggheat(m, function(p) {
    p + scale_fill_viridis_c() +
        ggplot2::geom_text(
            aes(label = sprintf("%s * %s", .row_index, .column_index))
        )
}, column_km = 2L), merge_legends = TRUE)
```

![image](https://github.com/jokergoo/ComplexHeatmap/assets/19575010/49103b00-c258-4a62-bf77-b32f475a0fca)
