### PR TITLE
guess `which` automatically for Heat

### DIFF
--- a/R/Heatmap-class.R
+++ b/R/Heatmap-class.R
@@ -833,6 +833,12 @@ Heatmap = function(matrix, col, name,
     .Object@column_dend_param$cluster_slices = cluster_column_slices
 
     ######### annotations #############
+    # the `top_annotation` will only be evaluated here due to the lazy
+    # evaluation, we set `.ENV$current_annotation_which` in order to
+    # HeatmapAnnotation can automatically set its `which` argument.
+    # the same will be applied for bottom, left, right annotation
+	old = set_annotation_which("column") # return the initial value
+    on.exit(set_annotation_which(old), add = TRUE)
     .Object@top_annotation = top_annotation # a `HeatmapAnnotation` object
     if(is.null(top_annotation)) {
         .Object@top_annotation_param$height = unit(0, "mm")    
@@ -858,7 +864,7 @@ Heatmap = function(matrix, col, name,
     if(!is.null(top_annotation)) {
         validate_anno_names_with_matrix(matrix, top_annotation, "column")
     }
-    
+    set_annotation_which("column") 
     .Object@bottom_annotation = bottom_annotation # a `HeatmapAnnotation` object
     if(is.null(bottom_annotation)) {
         .Object@bottom_annotation_param$height = unit(0, "mm")
@@ -884,7 +890,7 @@ Heatmap = function(matrix, col, name,
     if(!is.null(bottom_annotation)) {
         validate_anno_names_with_matrix(matrix, bottom_annotation, "column")
     }
-
+    set_annotation_which("row") 
     .Object@left_annotation = left_annotation # a `rowAnnotation` object
     if(is.null(left_annotation)) {
         .Object@left_annotation_param$width = unit(0, "mm")
@@ -910,7 +916,7 @@ Heatmap = function(matrix, col, name,
     if(!is.null(left_annotation)) {
         validate_anno_names_with_matrix(matrix, left_annotation, "row")
     }
-
+    set_annotation_which("row") 
     .Object@right_annotation = right_annotation # a `rowAnnotation` object
     if(is.null(right_annotation)) {
         .Object@right_annotation_param$width = unit(0, "mm")

--- a/R/HeatmapAnnotation-class.R
+++ b/R/HeatmapAnnotation-class.R
@@ -125,12 +125,10 @@ HeatmapAnnotation = function(...,
 	is_width_set = !missing(width)
 	is_annotation_height_set = !missing(annotation_height)
 	is_annotation_width_set = !missing(annotation_width)
-
-	.ENV$current_annotation_which = NULL
-	which = match.arg(which)[1]
-	.ENV$current_annotation_which = which
+	which = get_annotation_which(which)
+	old = set_annotation_which(which) # return the initial value
 	on.exit({
-		.ENV$current_annotation_which <- NULL
+		.ENV$current_annotation_which <- old
 		dev.off2()
 	})
 

--- a/R/global.R
+++ b/R/global.R
@@ -233,7 +233,7 @@ ht_opt = setGlobalOptions(
 ht_global_opt = function(..., RESET = FALSE, READ.ONLY = NULL, LOCAL = FALSE, ADD = FALSE) {}
 ht_global_opt = ht_opt
 
-.ENV = new.env()
+.ENV = new.env(parent = emptyenv())
 .ENV$current_annotation_which = NULL
 .ENV$row_order = NULL
 .ENV$row_pos = NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,6 +57,20 @@ increase_color_mapping_index = function() {
     INDEX_ENV$I_COLOR_MAPPING = INDEX_ENV$I_COLOR_MAPPING + 1
 }
 
+get_annotation_which = function(which) {
+    out = .ENV$current_annotation_which
+	if(is.null(out)) {
+		out = match.arg(which, c("column", "row"))
+	}
+    out
+}
+
+set_annotation_which = function(which) {
+    old = .ENV$current_annotation_which
+    .ENV$current_annotation_which = which
+    invisible(old)
+}
+
 # default colors for matrix or annotations
 # this function should be improved later
 default_col = function(x, main_matrix = FALSE) {


### PR DESCRIPTION
Now, it's no need to set `which` in `HeatmapAnnotation` function, we just guess it by argument, top_annotation, bottom_annotation, left_annotation and right_annotation, these can give exact `which`.

``` r
library(ggplot2)
library(ComplexHeatmap)
#> Loading required package: grid
#> ========================================
#> ComplexHeatmap version 2.15.4
#> Bioconductor page: http://bioconductor.org/packages/ComplexHeatmap/
#> Github page: https://github.com/jokergoo/ComplexHeatmap
#> Documentation: http://jokergoo.github.io/ComplexHeatmap-reference
#> 
#> If you use it in published research, please cite either one:
#> - Gu, Z. Complex Heatmap Visualization. iMeta 2022.
#> - Gu, Z. Complex heatmaps reveal patterns and correlations in multidimensional 
#>     genomic data. Bioinformatics 2016.
#> 
#> 
#> The new InteractiveComplexHeatmap package can directly export static 
#> complex heatmaps into an interactive Shiny app with zero effort. Have a try!
#> 
#> This message can be suppressed by:
#>   suppressPackageStartupMessages(library(ComplexHeatmap))
#> ========================================
x <- sample(1:10, 10L)
m <- matrix(rnorm(100), nrow = 10L)
rownames(m) <- paste0("row ", seq_len(nrow(m)))
colnames(m) <- paste0("col ", seq_len(ncol(m)))
draw(Heatmap(m,
  top_annotation = HeatmapAnnotation(
    foo = anno_points(x, height = unit(5, "cm"))
  )
))
```

![image](https://github.com/jokergoo/ComplexHeatmap/assets/19575010/3df71f14-a5a8-44f2-a098-c9dfb49fa266)

``` r
draw(Heatmap(m,
  bottom_annotation = HeatmapAnnotation(
    foo = anno_points(x, height = unit(5, "cm"))
  )
))
```

![image](https://github.com/jokergoo/ComplexHeatmap/assets/19575010/48a5f31d-09ed-4221-9785-264af6fe67a1)

``` r
draw(Heatmap(m,
  left_annotation = HeatmapAnnotation(
    foo = anno_points(x, width = unit(5, "cm"))
  )
))
```

![image](https://github.com/jokergoo/ComplexHeatmap/assets/19575010/4c094989-493b-439a-b921-c6c38a4a8e2f)

``` r
draw(Heatmap(m,
  right_annotation = HeatmapAnnotation(
    foo = anno_points(x, width = unit(5, "cm"))
  )
))
```

![image](https://github.com/jokergoo/ComplexHeatmap/assets/19575010/77ffbeb4-4697-4ee0-9017-5868f4cc4c8d)

<sup>Created on 2023-11-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
