### PR TITLE
Fix slow distance matrix calculation

### DIFF
--- a/ComplexHeatmap.Rproj
+++ b/ComplexHeatmap.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 3
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,3 +22,4 @@ Description: Complex heatmaps are efficient to visualize associations
 biocViews: Software, Visualization, Sequencing
 URL: https://github.com/jokergoo/ComplexHeatmap, https://jokergoo.github.io/ComplexHeatmap-reference/book/
 License: MIT + file LICENSE
+RoxygenNote: 7.2.3

--- a/R/utils.R
+++ b/R/utils.R
@@ -214,19 +214,12 @@ get_dist = function(matrix, method) {
         # }
     } else if(method %in% c("pearson", "spearman", "kendall")) {
         if(any(is.na(matrix))) {
-            dst = get_dist(matrix, function(x, y) {
-                    l = is.na(x) | is.na(y)
-                    x = x[!l]
-                    y = y[!l]
-                    1 - cor(x, y, method = method)
-                })
             warning_wrap("NA exists in the matrix, calculating distance by removing NA values.")
-        } else {
-            dst = switch(method,
-                         pearson = as.dist(1 - cor(t(matrix), method = "pearson")),
-                         spearman = as.dist(1 - cor(t(matrix), method = "spearman")),
-                         kendall = as.dist(1 - cor(t(matrix), method = "kendall")))
         }
+       dst = (1-cor(t(matrix),
+                    method = method,
+                    use = "pairwise.complete.obs"))/2
+       dst = as.dist(dst)
     } else {
         stop_wrap(qq("method @{method} not supported"))
     }


### PR DESCRIPTION
Distance matrix calculation is extremely slow when using correlation-based distance and NAs are present. The existing strategy utilizes nested for loops via the ComplexHeatmap:::dist2 function when NAs are present in the matrix. This solution is too slow for large matrices (e.g., 10000 x 100). These nested for loops can be avoided by using the use = "pairwise.complete.obs" argument of the stats::cor function yielding quick distance matrix calculation in the presence of NAs.